### PR TITLE
Implement streaming metrics

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -1,0 +1,100 @@
+package connect_go_prometheus
+
+import (
+	"time"
+
+	"github.com/bufbuild/connect-go"
+)
+
+type streamingConn struct {
+	startTime                 time.Time
+	callType, service, method string
+	reporter                  *Metrics
+}
+
+func newStreamingConn(spec connect.Spec, reporter *Metrics) streamingConn {
+	callPackage, callMethod := procedureToPackageAndMethod(spec.Procedure)
+	conn := streamingConn{
+		startTime: time.Now(),
+		callType:  steamTypeString(spec.StreamType),
+		service:   callPackage,
+		method:    callMethod,
+		reporter:  reporter,
+	}
+	reporter.requestStarted.WithLabelValues(conn.callType, conn.service, conn.method).Inc()
+	return conn
+}
+
+func (conn *streamingConn) reportSend() {
+	conn.reporter.streamMsgSent.WithLabelValues(conn.callType, conn.service, conn.method).Inc()
+}
+
+func (conn *streamingConn) reportReceive() {
+	conn.reporter.streamMsgReceived.WithLabelValues(conn.callType, conn.service, conn.method).Inc()
+}
+
+func (conn *streamingConn) reportHandled(err error) {
+	errCode := codeOf(err)
+	conn.reporter.requestHandled.WithLabelValues(conn.callType, conn.service, conn.method, errCode).Inc()
+	conn.reporter.ReportHandledSeconds(conn.callType, conn.service, conn.method, errCode, time.Since(conn.startTime).Seconds())
+}
+
+type streamingClientConn struct {
+	connect.StreamingClientConn
+	streamingConn
+}
+
+func newStreamingClientConn(conn connect.StreamingClientConn, i *Interceptor) *streamingClientConn {
+	return &streamingClientConn{
+		StreamingClientConn: conn,
+		streamingConn:       newStreamingConn(conn.Spec(), i.client),
+	}
+}
+
+func (conn *streamingClientConn) Send(msg any) error {
+	conn.reportSend()
+	return conn.StreamingClientConn.Send(msg)
+}
+
+func (conn *streamingClientConn) Receive(msg any) error {
+	err := conn.StreamingClientConn.Receive(msg)
+	if err == nil {
+		conn.reportReceive()
+	}
+	return err
+}
+
+func (conn *streamingClientConn) CloseResponse() error {
+	err := conn.StreamingClientConn.CloseResponse()
+	conn.reportHandled(err)
+	return err
+}
+
+var _ connect.StreamingClientConn = (*streamingClientConn)(nil)
+
+type streamingHandlerConn struct {
+	connect.StreamingHandlerConn
+	streamingConn
+}
+
+func newStreamingHandlerConn(conn connect.StreamingHandlerConn, i *Interceptor) *streamingHandlerConn {
+	return &streamingHandlerConn{
+		StreamingHandlerConn: conn,
+		streamingConn:        newStreamingConn(conn.Spec(), i.server),
+	}
+}
+
+func (conn *streamingHandlerConn) Send(msg any) error {
+	conn.reportSend()
+	return conn.StreamingHandlerConn.Send(msg)
+}
+
+func (conn *streamingHandlerConn) Receive(msg any) error {
+	err := conn.StreamingHandlerConn.Receive(msg)
+	if err == nil {
+		conn.reportReceive()
+	}
+	return err
+}
+
+var _ connect.StreamingHandlerConn = (*streamingHandlerConn)(nil)

--- a/interceptor.go
+++ b/interceptor.go
@@ -2,6 +2,7 @@ package connect_go_prometheus
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"time"
 
@@ -118,7 +119,15 @@ func codeOf(err error) string {
 	if err == nil {
 		return CodeOk
 	}
-	return connect.CodeOf(err).String()
+	code := connect.CodeOf(err)
+	if code == connect.CodeUnknown {
+		if errors.Is(err, context.Canceled) {
+			code = connect.CodeCanceled
+		} else if errors.Is(err, context.DeadlineExceeded) {
+			code = connect.CodeDeadlineExceeded
+		}
+	}
+	return code.String()
 }
 
 type interceptorOptions struct {

--- a/interceptor.go
+++ b/interceptor.go
@@ -13,7 +13,7 @@ const (
 	CodeOk = "ok"
 )
 
-func NewInterceptor(opts ...InterecptorOption) *Interceptor {
+func NewInterceptor(opts ...InterceptorOption) *Interceptor {
 	options := evaluteInterceptorOptions(&interceptorOptions{
 		client: DefaultClientMetrics,
 		server: DefaultServerMetrics,
@@ -135,21 +135,21 @@ type interceptorOptions struct {
 	server *Metrics
 }
 
-type InterecptorOption func(*interceptorOptions)
+type InterceptorOption func(*interceptorOptions)
 
-func WithClientMetrics(m *Metrics) InterecptorOption {
+func WithClientMetrics(m *Metrics) InterceptorOption {
 	return func(io *interceptorOptions) {
 		io.client = m
 	}
 }
 
-func WithServerMetrics(m *Metrics) InterecptorOption {
+func WithServerMetrics(m *Metrics) InterceptorOption {
 	return func(io *interceptorOptions) {
 		io.server = m
 	}
 }
 
-func evaluteInterceptorOptions(defaults *interceptorOptions, opts ...InterecptorOption) *interceptorOptions {
+func evaluteInterceptorOptions(defaults *interceptorOptions, opts ...InterceptorOption) *interceptorOptions {
 	for _, opt := range opts {
 		opt(defaults)
 	}

--- a/interceptor.go
+++ b/interceptor.go
@@ -8,6 +8,10 @@ import (
 	"github.com/bufbuild/connect-go"
 )
 
+const (
+	CodeOk = "ok"
+)
+
 func NewInterceptor(opts ...InterecptorOption) *Interceptor {
 	options := evaluteInterceptorOptions(&interceptorOptions{
 		client: DefaultClientMetrics,
@@ -112,7 +116,7 @@ func steamTypeString(st connect.StreamType) string {
 
 func codeOf(err error) string {
 	if err == nil {
-		return "ok"
+		return CodeOk
 	}
 	return connect.CodeOf(err).String()
 }

--- a/metrics.go
+++ b/metrics.go
@@ -53,7 +53,7 @@ func NewServerMetrics(opts ...MetricsOption) *Metrics {
 			Subsystem:   config.subsystem,
 			ConstLabels: config.constLabels,
 			Name:        config.streamMsgReceivedName,
-			Help:        "Total number of stream messages recieved by server-side",
+			Help:        "Total number of stream messages received by server-side",
 		}, []string{"type", "service", "method"}),
 	}
 
@@ -108,7 +108,7 @@ func NewClientMetrics(opts ...MetricsOption) *Metrics {
 			Subsystem:   config.subsystem,
 			ConstLabels: config.constLabels,
 			Name:        config.streamMsgReceivedName,
-			Help:        "Total number of stream messages recieved by client-side",
+			Help:        "Total number of stream messages received by client-side",
 		}, []string{"type", "service", "method"}),
 	}
 


### PR DESCRIPTION
Also fixes:
* Typo in `streamMsgReceived` help text
* `streamMsgSent` and `streamMsgReceived` being swapped on the server side for unary RPCs
* `ReportHandled` was unconditionally calling incrementing the message count even in the case of error
* Assigns a code to `context.Canceled` and `context.DeadlineExceeded`